### PR TITLE
[AEM CS Deployment] Suppress false positives during SonarQube scan

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/dam/AbstractRenditionModifyingProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/AbstractRenditionModifyingProcess.java
@@ -125,6 +125,7 @@ public abstract class AbstractRenditionModifyingProcess {
 
     }
 
+    @SuppressWarnings("findsecbugs:PATH_TRAVERSAL_IN")
     void saveImage(Asset asset, Rendition toReplace, Layer layer, String mimetype, double quality, WorkflowHelper workflowHelper)
             throws IOException {
         File tmpFile = File.createTempFile(getTempFileSpecifier(), "." + workflowHelper.getExtension(mimetype));

--- a/bundle/src/main/java/com/adobe/acs/commons/dam/AbstractRenditionModifyingProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/AbstractRenditionModifyingProcess.java
@@ -124,7 +124,8 @@ public abstract class AbstractRenditionModifyingProcess {
         }
 
     }
-
+    
+    // False positive, file path not controlled by the user
     @SuppressWarnings("findsecbugs:PATH_TRAVERSAL_IN")
     void saveImage(Asset asset, Rendition toReplace, Layer layer, String mimetype, double quality, WorkflowHelper workflowHelper)
             throws IOException {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/util/CacheUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/util/CacheUtils.java
@@ -55,6 +55,8 @@ public class CacheUtils {
      * @param cacheKey
      * @return
      */
+
+    @SuppressWarnings("findsecbugs:PATH_TRAVERSAL_IN")
     public static File createTemporaryCacheFile(CacheKey cacheKey) throws IOException {
         // Create a file in Java temp directory with cacheKey.toSting() as file name.
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/util/CacheUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/util/CacheUtils.java
@@ -55,7 +55,7 @@ public class CacheUtils {
      * @param cacheKey
      * @return
      */
-
+    // False positive, file path not controlled by the user
     @SuppressWarnings("findsecbugs:PATH_TRAVERSAL_IN")
     public static File createTemporaryCacheFile(CacheKey cacheKey) throws IOException {
         // Create a file in Java temp directory with cacheKey.toSting() as file name.


### PR DESCRIPTION
User does not control the tempfile name creation